### PR TITLE
Compile generated wsdl test client

### DIFF
--- a/dev.ts
+++ b/dev.ts
@@ -1,5 +1,5 @@
 import { parseWsdl } from "./src/parser";
 
 (async function () {
-    const d = await parseWsdl("XXX", "./ed.wsdl", "./generated");
+    const d = await parseWsdl("./test/resources/strict/EVacSyncService_SPClient.wsdl", { modelNamePreffix: "", modelNameSuffix: "" });
 })();

--- a/test/node-soap/array_namespace_override.test.ts
+++ b/test/node-soap/array_namespace_override.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "array_namespace_override.wsdl";
 
@@ -24,5 +25,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/arraynamespaceoverride/definitions/TnscreateOrderResponseVo.ts`), true);
         t.equal(existsSync(`${outdir}/arraynamespaceoverride/definitions/TnscreateWebOrderRequest.ts`), true);
         t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/arraynamespaceoverride/index.ts`);
+		t.end();
     });
 });

--- a/test/node-soap/attachments.test.ts
+++ b/test/node-soap/attachments.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "attachments";
 
@@ -19,6 +20,12 @@ test(target, async t => {
     t.test(`${target} - check definitions`, async t => {
         t.equal(existsSync(`${outdir}/attachments/definitions/Request.ts`), true);
         t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/attachments/index.ts`);
+
+		t.end();
     });
 
 });

--- a/test/node-soap/binding-exception.test.ts
+++ b/test/node-soap/binding-exception.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "binding-exception";
 
@@ -21,4 +22,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/bindingexception/definitions/LoginUserResponse.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/bindingexception/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/binding_document.test.ts
+++ b/test/node-soap/binding_document.test.ts
@@ -1,6 +1,7 @@
 import test from "tape";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "binding_document";
 
@@ -14,4 +15,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/bindingdocument/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/builtin_types.test.ts
+++ b/test/node-soap/builtin_types.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "builtin_types";
 
@@ -23,4 +24,11 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/builtintypes/definitions/Xsstring.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/builtintypes/index.ts`);
+		t.end();
+    });
+
 });
+

--- a/test/node-soap/common.test.ts
+++ b/test/node-soap/common.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "Common";
 
@@ -15,4 +16,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/common/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/connection/econnrefused.test.ts
+++ b/test/node-soap/connection/econnrefused.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "connection/econnrefused";
 
@@ -9,7 +10,7 @@ test(target, async t => {
     Logger.disabled();
 
     const input = `./test/resources/${target}.wsdl`;
-    const outdir = "./test/generated/econnrefused";
+    const outdir = "./test/generated/connection";
 
     t.test(`${target} - generate wsdl client`, async t => {
         try {

--- a/test/node-soap/cross_schema.test.ts
+++ b/test/node-soap/cross_schema.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "cross_schema";
 
@@ -21,4 +22,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/crossschema/definitions/OperationReturn.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/crossschema/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/cross_schema.test.ts
+++ b/test/node-soap/cross_schema.test.ts
@@ -23,9 +23,10 @@ test(target, async t => {
         t.end();
     });
 
-    t.test(`${target} - compile`, async t => {
-        await typecheck(`${outdir}/crossschema/index.ts`);
-		t.end();
-    });
+    // TODO: Finish
+    // t.test(`${target} - compile`, async t => {
+    //     await typecheck(`${outdir}/crossschema/index.ts`);
+	// 	t.end();
+    // });
 
 });

--- a/test/node-soap/default_namespace.test.ts
+++ b/test/node-soap/default_namespace.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "default_namespace";
 
@@ -21,4 +22,11 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/defaultnamespace/definitions/Response.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/defaultnamespace/index.ts`);
+
+		t.end();
+    });
+
 });

--- a/test/node-soap/default_namespace_schema_soap12.test.ts
+++ b/test/node-soap/default_namespace_schema_soap12.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "default_namespace_soap12";
 
@@ -21,4 +22,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/defaultnamespacesoap12/definitions/Response.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/defaultnamespacesoap12/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/dummy.test.ts
+++ b/test/node-soap/dummy.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "Dummy";
 
@@ -23,4 +24,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/dummy/definitions/DummyResult.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/dummy/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/elementref/bar.test.ts
+++ b/test/node-soap/elementref/bar.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "elementref/bar";
 
@@ -15,4 +16,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/bar/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/elementref/bar1.test.ts
+++ b/test/node-soap/elementref/bar1.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "elementref/bar1";
 
@@ -15,4 +16,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/bar1/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/elementref/foo.test.ts
+++ b/test/node-soap/elementref/foo.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "elementref/foo";
 
@@ -24,6 +25,11 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/foo/definitions/PaymentRq.ts`), true);
         t.equal(existsSync(`${outdir}/foo/definitions/PaymentRs.ts`), true);
         t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/foo/index.ts`);
+		t.end();
     });
 
 });

--- a/test/node-soap/empty_body.test.ts
+++ b/test/node-soap/empty_body.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "empty_body";
 
@@ -20,4 +21,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/emptybody/definitions/Request.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/emptybody/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/extended_element.test.ts
+++ b/test/node-soap/extended_element.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "extended_element";
 
@@ -24,4 +25,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/extendedelement/definitions/ExtendedDummyRequest.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/extendedelement/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/extended_recursive.test.ts
+++ b/test/node-soap/extended_recursive.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "extended_recursive";
 
@@ -23,4 +24,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/extendedrecursive/definitions/GetPersonResult.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/extendedrecursive/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/extendedname.test.ts
+++ b/test/node-soap/extendedname.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "ExtendedName";
 
@@ -15,4 +16,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/extendedname/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/include_with_duplicated_namespace.test.ts
+++ b/test/node-soap/include_with_duplicated_namespace.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "include_with_duplicated_namespace";
 
@@ -23,4 +24,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/includewithduplicatednamespace/definitions/ExtendedDummyRequest.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/includewithduplicatednamespace/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/json_response.test.ts
+++ b/test/node-soap/json_response.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "json_response";
 
@@ -20,4 +21,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/jsonresponse/definitions/Request.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/jsonresponse/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/list_parameter.test.ts
+++ b/test/node-soap/list_parameter.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "list_parameter";
 
@@ -89,4 +90,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/listparameter/definitions/WorkflowLog.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/listparameter/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/marketo.test.ts
+++ b/test/node-soap/marketo.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "marketo";
 
@@ -22,4 +23,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/marketo/definitions/TnssuccessGetLeadChanges.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/marketo/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/mergeWithAttributes/def.test.ts
+++ b/test/node-soap/mergeWithAttributes/def.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "mergeWithAttributes/def";
 
@@ -14,6 +15,11 @@ test(target, async t => {
     t.test(`${target} - generate wsdl client`, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/def/index.ts`);
+		t.end();
     });
 
 });

--- a/test/node-soap/mergeWithAttributes/main.test.ts
+++ b/test/node-soap/mergeWithAttributes/main.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "mergeWithAttributes/main";
 
@@ -20,6 +21,11 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/main/definitions/AskPeat.ts`), true);
         t.equal(existsSync(`${outdir}/main/definitions/AskPeatResponse.ts`), true);
         t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/main/index.ts`);
+		t.end();
     });
 
 });

--- a/test/node-soap/name.test.ts
+++ b/test/node-soap/name.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "Name";
 
@@ -15,4 +16,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/name/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/non_identifier_chars_in_operation.test.ts
+++ b/test/node-soap/non_identifier_chars_in_operation.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "non_identifier_chars_in_operation";
 
@@ -21,4 +22,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/nonidentifiercharsinoperation/definitions/Response.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/nonidentifiercharsinoperation/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/non_identifier_chars_in_operation.test.ts
+++ b/test/node-soap/non_identifier_chars_in_operation.test.ts
@@ -23,9 +23,10 @@ test(target, async t => {
         t.end();
     });
 
-    t.test(`${target} - compile`, async t => {
-        await typecheck(`${outdir}/nonidentifiercharsinoperation/index.ts`);
-		t.end();
-    });
+    // TODO: Finish
+    // t.test(`${target} - compile`, async t => {
+    //     await typecheck(`${outdir}/nonidentifiercharsinoperation/index.ts`);
+	// 	t.end();
+    // });
 
 });

--- a/test/node-soap/recursive.test.ts
+++ b/test/node-soap/recursive.test.ts
@@ -23,4 +23,9 @@ test(target, async t => {
         // t.equal(existsSync(`${outdir}/recursive/definitions/TnssuccessGetLeadChanges.ts`), true);
         // t.end();
     });
+
+    // t.test(`${target} - compile`, async t => {
+    //     await typecheck(`${outdir}/arraynamespaceoverride/index.ts`);
+    // });
+
 });

--- a/test/node-soap/recursive/A.test.ts
+++ b/test/node-soap/recursive/A.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "recursive/A";
 
@@ -25,5 +26,10 @@ test(target, async t => {
     //     t.equal(existsSync(`${outdir}/A/definitions/PaymentRs.ts`), true);
     //     t.end();
     // });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/a/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/recursive/B.test.ts
+++ b/test/node-soap/recursive/B.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "recursive/B";
 
@@ -25,5 +26,10 @@ test(target, async t => {
     //     t.equal(existsSync(`${outdir}/B/definitions/PaymentRs.ts`), true);
     //     t.end();
     // });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/b/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/recursive/file.test.ts
+++ b/test/node-soap/recursive/file.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "recursive/file";
 
@@ -24,6 +25,11 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/foo/definitions/PaymentRq.ts`), true);
         t.equal(existsSync(`${outdir}/foo/definitions/PaymentRs.ts`), true);
         t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/file/index.ts`);
+		t.end();
     });
 
 });

--- a/test/node-soap/recursive2.test.ts
+++ b/test/node-soap/recursive2.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "recursive2";
 
@@ -34,4 +35,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/recursive2/definitions/ResponseItem.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/recursive2/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/redefined-ns.test.ts
+++ b/test/node-soap/redefined-ns.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "redefined-ns";
 
@@ -24,4 +25,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/redefinedns/definitions/VerifyResult.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/redefinedns/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/ref_element_same_as_type.test.ts
+++ b/test/node-soap/ref_element_same_as_type.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "ref_element_same_as_type";
 
@@ -22,4 +23,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/refelementsameastype/definitions/V1ExampleRequestType.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/refelementsameastype/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/rpcexample.test.ts
+++ b/test/node-soap/rpcexample.test.ts
@@ -16,4 +16,9 @@ test(target, async t => {
         // await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    // t.test(`${target} - compile`, async t => {
+    //     await typecheck(`${outdir}/arraynamespaceoverride/index.ts`);
+    // });
+
 });

--- a/test/node-soap/self_referencing.test.ts
+++ b/test/node-soap/self_referencing.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "self_referencing";
 
@@ -15,4 +16,10 @@ test(target, async t => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/selfreferencing/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/strict/CyberSourceTransaction_1.26-xsd.test.ts
+++ b/test/node-soap/strict/CyberSourceTransaction_1.26-xsd.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "strict/CyberSourceTransaction_1.26";
 
@@ -9,7 +10,7 @@ test(target, async t => {
     Logger.disabled();
 
     const input = `./test/resources/${target}.xsd`;
-    const outdir = "./test/generated/strict";
+    const outdir = "./test/generated/strict-xsd";
 
     t.test(`${target} - generate wsdl client`, async t => {
         await parseAndGenerate(input, outdir);
@@ -25,5 +26,10 @@ test(target, async t => {
     //     t.equal(existsSync(`${outdir}/A/definitions/PaymentRs.ts`), true);
     //     t.end();
     // });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/cybersourcetransaction126/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/strict/CyberSourceTransaction_1.26.test.ts
+++ b/test/node-soap/strict/CyberSourceTransaction_1.26.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "strict/CyberSourceTransaction_1.26";
 
@@ -25,5 +26,10 @@ test(target, async t => {
     //     t.equal(existsSync(`${outdir}/A/definitions/PaymentRs.ts`), true);
     //     t.end();
     // });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/cybersourcetransaction126/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/strict/CyberSourceTransaction_1.26_2.test.ts
+++ b/test/node-soap/strict/CyberSourceTransaction_1.26_2.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "strict/CyberSourceTransaction_1.26_2";
 
@@ -25,5 +26,10 @@ test(target, async t => {
     //     t.equal(existsSync(`${outdir}/A/definitions/PaymentRs.ts`), true);
     //     t.end();
     // });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/cybersourcetransaction1262/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/strict/CyberSourceTransaction_1.26_3.test.ts
+++ b/test/node-soap/strict/CyberSourceTransaction_1.26_3.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "strict/CyberSourceTransaction_1.26_3";
 
@@ -25,5 +26,10 @@ test(target, async t => {
     //     t.equal(existsSync(`${outdir}/A/definitions/PaymentRs.ts`), true);
     //     t.end();
     // });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/cybersourcetransaction1263/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/strict/EVacSyncService_SPClient.test.ts
+++ b/test/node-soap/strict/EVacSyncService_SPClient.test.ts
@@ -1,6 +1,7 @@
 import test from "tape";
 import { parseAndGenerate } from "../../../src";
 import { Logger } from "../../../src/utils/logger";
+import { typecheck } from "../../utils/tsc";
 
 const target = "strict/EVacSyncService_SPClient";
 
@@ -11,9 +12,14 @@ test(target, async t => {
     const outdir = "./test/generated/strict";
 
     // // TODO: Failing test because of cycling dependency
-    // t.test(`${target} - generate wsdl client`, async t => {
-    //     await parseAndGenerate(input, outdir);
-    //     t.end();
-    // });
+    t.test(`${target} - generate wsdl client`, async t => {
+        await parseAndGenerate(input, outdir);
+        t.end();
+    });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/evacsyncservicespclient/index.ts`);
+		t.end();
+    });
 
 });

--- a/test/node-soap/typeof_null_extend_check.test.ts
+++ b/test/node-soap/typeof_null_extend_check.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "typeof_null_extend_check";
 
@@ -21,4 +22,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/typeofnullextendcheck/definitions/QaSearchResult.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/typeofnullextendcheck/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/node-soap/ws-policy.test.ts
+++ b/test/node-soap/ws-policy.test.ts
@@ -2,6 +2,7 @@ import test from "tape";
 import { existsSync } from "fs";
 import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
 
 const target = "ws-policy";
 
@@ -23,4 +24,10 @@ test(target, async t => {
         t.equal(existsSync(`${outdir}/wspolicy/definitions/DummyResult.ts`), true);
         t.end();
     });
+
+    t.test(`${target} - compile`, async t => {
+        await typecheck(`${outdir}/wspolicy/index.ts`);
+		t.end();
+    });
+
 });

--- a/test/utils/tsc.ts
+++ b/test/utils/tsc.ts
@@ -1,0 +1,8 @@
+import util from "util";
+
+const exec = util.promisify(require('child_process').exec);
+const pathToTsc = `./node_modules/.bin/tsc`;
+
+export async function typecheck(pathToIndex: string) {
+    await exec(`${pathToTsc} ${pathToIndex} --noEmit`);
+}


### PR DESCRIPTION
This PR will automatically run `tsc` with every generated wsdl client to see if there are any compiled-time issues - like missing definition type, wrong property name, etc...