### PR TITLE
fix for insensitive names and use of prefix and suffix

### DIFF
--- a/src/models/parsed-wsdl.ts
+++ b/src/models/parsed-wsdl.ts
@@ -80,12 +80,16 @@ export interface Options {
      * @default 32
      */
     maxStackWarn: number;
+    modelNamePreffix: string;
+    modelNameSuffix: string;
 }
 
 const defaultOptions: Options = {
     caseInsensitiveNames: false,
     maxStack: 64,
     maxStackWarn: 32,
+    modelNamePreffix: "",
+    modelNameSuffix: "",
 };
 
 export class ParsedWsdl {
@@ -129,7 +133,11 @@ export class ParsedWsdl {
         const definitionName = sanitizeFilename(defName);
         const isInSensitive = this._options.caseInsensitiveNames;
 
-        const defNameToCheck = isInSensitive ? definitionName.toLowerCase() : definitionName;
+        let defNameToCheck = `${this._options.modelNamePreffix}${definitionName}${this._options.modelNameSuffix}`;
+        if (isInSensitive) {
+            defNameToCheck = defNameToCheck.toLowerCase();
+        }
+
         if (
             !this.definitions.find((def) =>
                 isInSensitive ? def.name.toLowerCase() === defNameToCheck : def.name === defNameToCheck

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,12 +11,14 @@ interface ParserOptions {
     modelNamePreffix: string;
     modelNameSuffix: string;
     maxRecursiveDefinitionName: number;
+    caseInsensitiveNames: boolean
 }
 
 const defaultOptions: ParserOptions = {
     modelNamePreffix: "",
     modelNameSuffix: "",
     maxRecursiveDefinitionName: 64,
+    caseInsensitiveNames: false
 };
 
 type VisitedDefinition = {
@@ -239,7 +241,12 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                     return reject(new Error("WSDL is undefined"));
                 }
 
-                const parsedWsdl = new ParsedWsdl({ maxStack: options.maxRecursiveDefinitionName });
+                const parsedWsdl = new ParsedWsdl({
+                    maxStack: options.maxRecursiveDefinitionName,
+                    caseInsensitiveNames: options.caseInsensitiveNames,
+                    modelNamePreffix: options.modelNamePreffix,
+                    modelNameSuffix: options.modelNameSuffix
+                });
                 const filename = path.basename(wsdlPath);
                 parsedWsdl.name = changeCase(stripExtension(filename), {
                     pascalCase: true,


### PR DESCRIPTION
Apparently parsed-wsdl was not taking into account of caseInsensitiveNames, modelNamePreffix and modelNameSuffix which are key elements to find duplicates. (Expecially prefix and suffix).

this fixes duplicate entries and related typescript errors.

Ex:
https://github.com/dderevjanik/wsdl-tsclient/issues/25
