### PR TITLE
Fix: null definitions and failing tests

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -126,6 +126,18 @@ function generateDefinitionFile(
     defFile.saveSync();
 }
 
+function checkDefinition(paramDefinition: Definition) {
+    if (paramDefinition) {
+        return paramDefinition.name;
+    }
+
+    if (paramDefinition === null) {
+        return "null";
+    }
+
+    return "{}";
+}
+
 export async function generate(
     parsedWsdl: ParsedWsdl,
     outDir: string,
@@ -217,7 +229,7 @@ export async function generate(
                     parameters: [
                         {
                             name: camelcase(method.paramName),
-                            type: method.paramDefinition ? method.paramDefinition.name : "{}",
+                            type: checkDefinition(method.paramDefinition),
                         },
                         {
                             name: "callback",
@@ -297,7 +309,7 @@ export async function generate(
                     parameters: [
                         {
                             name: camelcase(method.paramName),
-                            type: method.paramDefinition ? method.paramDefinition.name : "{}",
+                            type: checkDefinition(method.paramDefinition),
                         },
                     ],
                     returnType: `Promise<[result: ${

--- a/test/resources-public/products.test.ts
+++ b/test/resources-public/products.test.ts
@@ -18,12 +18,12 @@ test(target, async t => {
     });
 
     t.test(`${target} - check definitions`, async t => {
-        t.equal(existsSync(`${outdir}/foo/definitions/BankSvcRq.ts`), true);
+        t.equal(existsSync(`${outdir}/products/definitions/Discount.ts`), true);
         t.end();
     });
 
     t.test(`${target} - compile`, async t => {
-        await typecheck(`${outdir}/file/index.ts`);
+        await typecheck(`${outdir}/products/index.ts`);
 		t.end();
     });
 


### PR DESCRIPTION
If a message is null it was applying `"{}"`. This was giving an error of: 'invalid message definition for rpc style binding'. This is because in the soap client module the input.parts is null but the args = {}. See the following:
```
if ((style === 'rpc') && ((input.parts || input.name === 'element') || args === null)) {
            assert.ok(!style || style === 'rpc', 'invalid message definition for document style binding');
            message = this.wsdl.objectToRpcXML(name, args, alias, ns, (input.name !== 'element'));
            (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
        }
        else {
            assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
            // pass `input.$lookupType` if `input.$type` could not be found
            message = this.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
        }
``` 

This fixes the issue.
Also two tests were broken.