### PR TITLE
[Discussion]: proposed changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
+    "@types/glob": "8.0.0",
     "@types/node": "^17.0.24",
     "@types/supports-color": "^8.1.0",
     "@types/tape": "^4.13.2",
@@ -58,6 +59,7 @@
     "chalk": "^4.1.1",
     "eslint": "^8.13.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "glob": "8.0.3",
     "sanitize-filename": "^1.6.3",
     "soap": "^0.43.0",
     "supports-color": "^8.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,9 @@ import yargs from "yargs";
 import path from "path";
 import { Logger } from "./utils/logger";
 import { parseAndGenerate, Options } from "./index";
+import glob from 'glob';
 import packageJson from "../package.json";
+import { promisify } from "util";
 
 const conf = yargs(process.argv.slice(2))
     .version(packageJson.version)
@@ -125,8 +127,13 @@ if (conf._ === undefined || conf._.length === 0) {
         const outDir = path.resolve(conf.o);
 
         let errorsCount = 0;
-        const matches = conf._ as string[];
-
+        let patterns = conf._ as string[];
+        Logger.debug(`patterns: ${patterns}`);
+        let matches: string[] = [];
+        for (const pattern of patterns) {
+          const expanded = await promisify(glob)(pattern);
+          matches = matches.concat(expanded);
+        }
         if (matches.length > 1) {
             Logger.debug(matches.map((m) => path.resolve(m)).join("\n"));
             Logger.log(`Found ${matches.length} wsdl files`);

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -28,12 +28,14 @@ const defaultOptions: GeneratorOptions = {
 function addSafeImport(
     imports: OptionalKind<ImportDeclarationStructure>[],
     moduleSpecifier: string,
-    namedImport: string
+    namedImport: string,
+    isTypeOnly: boolean = false
 ) {
     if (!imports.find((imp) => imp.moduleSpecifier == moduleSpecifier)) {
         imports.push({
             moduleSpecifier,
             namedImports: [{ name: namedImport }],
+            isTypeOnly
         });
     }
 }
@@ -105,7 +107,7 @@ function generateDefinitionFile(
             }
             // If a property is of the same type as its parent type, don't add import
             if (prop.ref.name !== definition.name) {
-                addSafeImport(definitionImports, `./${prop.ref.name}`, prop.ref.name);
+                addSafeImport(definitionImports, `./${prop.ref.name}.js`, prop.ref.name, true);
             }
             definitionProperties.push(createProperty(prop.name, prop.ref.name, prop.sourceName, prop.isArray));
         }
@@ -177,14 +179,16 @@ export async function generate(
                         );
                         addSafeImport(
                             clientImports,
-                            `./definitions/${method.paramDefinition.name}`,
-                            method.paramDefinition.name
+                            `./definitions/${method.paramDefinition.name}.js`,
+                            method.paramDefinition.name,
+                            true
                         );
                     }
                     addSafeImport(
                         portImports,
-                        `../definitions/${method.paramDefinition.name}`,
-                        method.paramDefinition.name
+                        `../definitions/${method.paramDefinition.name}.js`,
+                        method.paramDefinition.name,
+                        true
                     );
                 }
                 if (method.returnDefinition !== null) {
@@ -200,14 +204,16 @@ export async function generate(
                         );
                         addSafeImport(
                             clientImports,
-                            `./definitions/${method.returnDefinition.name}`,
-                            method.returnDefinition.name
+                            `./definitions/${method.returnDefinition.name}.js`,
+                            method.returnDefinition.name,
+                            true
                         );
                     }
                     addSafeImport(
                         portImports,
-                        `../definitions/${method.returnDefinition.name}`,
-                        method.returnDefinition.name
+                        `../definitions/${method.returnDefinition.name}.js`,
+                        method.returnDefinition.name,
+                        true
                     );
                 }
                 // TODO: Deduplicate PortMethods
@@ -230,7 +236,7 @@ export async function generate(
                 });
             } // End of PortMethod
             if (!mergedOptions.emitDefinitionsOnly) {
-                addSafeImport(serviceImports, `../ports/${port.name}`, port.name);
+                addSafeImport(serviceImports, `../ports/${port.name}.js`, port.name, true);
                 servicePorts.push({
                     name: sanitizePropName(port.name),
                     isReadonly: true,
@@ -252,7 +258,7 @@ export async function generate(
         } // End of Port
 
         if (!mergedOptions.emitDefinitionsOnly) {
-            addSafeImport(clientImports, `./services/${service.name}`, service.name);
+            addSafeImport(clientImports, `./services/${service.name}.js`, service.name, true);
             clientServices.push({ name: sanitizePropName(service.name), type: service.name });
 
             serviceFile.addImportDeclarations(serviceImports);

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export const defaultOptions: Options = {
 };
 
 export async function parseAndGenerate(
-    wsdlPath: string,
+    wsdlUri: string,
     outDir: string,
     options: Partial<Options> = {}
 ): Promise<void> {
@@ -95,7 +95,7 @@ export async function parseAndGenerate(
     // Logger.debug(`Options: ${JSON.stringify(mergedOptions, null, 2)}`);
 
     const timeParseStart = process.hrtime();
-    const parsedWsdl = await parseWsdl(wsdlPath, mergedOptions);
+    const parsedWsdl = await parseWsdl(wsdlUri, mergedOptions);
     Logger.debug(`Parser time: ${timeElapsed(process.hrtime(timeParseStart))}ms`);
 
     const timeGenerateStart = process.hrtime();

--- a/src/models/parsed-wsdl.ts
+++ b/src/models/parsed-wsdl.ts
@@ -90,15 +90,16 @@ const defaultOptions: Options = {
 
 export class ParsedWsdl {
     /**
-     * Name is always uppercased filename of wsdl without an extension.
+     * Name is always uppercased filename of wsdl without an extension
+     * or the last URL path component without the query string.
      * Used to generate client name of interface
      * @example "MyClient"
      */
     name: string;
-    /** Original wsdl filename */
-    wsdlFilename: string;
+    /** Original wsdl basename */
+    wsdlBasename: string;
     /** Absolute basepath or url */
-    wsdlPath: string;
+    wsdlUri: string;
 
     definitions: Array<Definition> = [];
     ports: Array<Port> = [];

--- a/src/models/parsed-wsdl.ts
+++ b/src/models/parsed-wsdl.ts
@@ -98,7 +98,7 @@ export class ParsedWsdl {
     name: string;
     /** Original wsdl basename */
     wsdlBasename: string;
-    /** Absolute basepath or url */
+    /** Relative path or url */
     wsdlUri: string;
 
     definitions: Array<Definition> = [];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -244,7 +244,7 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                 parsedWsdl.name = changeCase(stripExtension(filename), {
                     pascalCase: true,
                 });
-                parsedWsdl.wsdlFilename = path.basename(filename);
+                parsedWsdl.wsdlFilename = filename;
                 parsedWsdl.wsdlPath = path.resolve(wsdlPath);
 
                 const visitedDefinitions: Array<VisitedDefinition> = [];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,7 @@ import { changeCase } from "./utils/change-case";
 import { stripExtension } from "./utils/file";
 import { reservedKeywords } from "./utils/javascript";
 import { Logger } from "./utils/logger";
+import { isUrl, stripQuery } from "./utils/url";
 
 interface ParserOptions {
     modelNamePreffix: string;
@@ -220,16 +221,17 @@ function parseDefinition(
 // TODO: Add comments for services, ports, methods and client
 /**
  * Parse WSDL to domain model `ParsedWsdl`
- * @param wsdlPath - path or url to wsdl file
+ * @param wsdlUri - path or url to wsdl file
  */
-export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions>): Promise<ParsedWsdl> {
+export async function parseWsdl(wsdlUri: string, options: Partial<ParserOptions>): Promise<ParsedWsdl> {
     const mergedOptions: ParserOptions = {
         ...defaultOptions,
         ...options,
     };
+    wsdlUri = isUrl(wsdlUri) ? wsdlUri : path.resolve(wsdlUri);
     return new Promise((resolve, reject) => {
         open_wsdl(
-            wsdlPath,
+            wsdlUri,
             { namespaceArrayElements: false, ignoredNamespaces: ["tns", "targetNamespace", "typeNamespace"] },
             function (err, wsdl) {
                 if (err) {
@@ -240,12 +242,17 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                 }
 
                 const parsedWsdl = new ParsedWsdl({ maxStack: options.maxRecursiveDefinitionName });
-                const filename = path.basename(wsdlPath);
-                parsedWsdl.name = changeCase(stripExtension(filename), {
-                    pascalCase: true,
-                });
-                parsedWsdl.wsdlFilename = filename;
-                parsedWsdl.wsdlPath = path.resolve(wsdlPath);
+                const basename = path.basename(wsdlUri);
+                parsedWsdl.name = changeCase(
+                    isUrl(wsdlUri)
+                        ? stripQuery(basename)
+                        : stripExtension(basename),
+                    {
+                        pascalCase: true,
+                    }
+                );
+                parsedWsdl.wsdlBasename = basename;
+                parsedWsdl.wsdlUri = wsdlUri;
 
                 const visitedDefinitions: Array<VisitedDefinition> = [];
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -228,7 +228,6 @@ export async function parseWsdl(wsdlUri: string, options: Partial<ParserOptions>
         ...defaultOptions,
         ...options,
     };
-    wsdlUri = isUrl(wsdlUri) ? wsdlUri : path.resolve(wsdlUri);
     return new Promise((resolve, reject) => {
         open_wsdl(
             wsdlUri,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,10 @@
+/**
+ * @example isUrl("https://domain.com") -> true
+ */
+export function isUrl(uri: string): boolean {
+    return /^https?:\/\//.test(uri);
+}
+
+export function stripQuery(url: string): string {
+    return url.replace(/^(.*?)\?.*$/, "$1");
+}


### PR DESCRIPTION
Thank You for the amazing work put into creating this tool.

However, I had to fork this repo in order to make some tweaks to suit my use case. Here are the changes made:

#### Emit imports with `import type ...` when importing only types
This is to comply with my tsconfig option `"importsNotUsedAsValues": "error"`.

#### Append `.js` to imported module
To comply with ESM.

#### Expand glob patterns internally
So that I can write a 
```json
  "scripts": { 
    "generate": "wsdl-tsconfig './wsdl/**/*.wsdl' -o ./generated"
  }
```
#### Support wsdl URI as either path or URL
Such that the build is up-to-date with the live service without having redownload the wsdls. Build/tests would break when service makes breaking changes.

#### Pre-configure `createClientAsync` with provided URI
The wsdl URI should only have to be provided once. The exported `createClientAsync` still takes the remaining parameters which could conflict with the parsing - room for improvement here.

----

I ended up not utilizing glob matching and build against live wsdls.

This PR is only intended to start a discussion on whether these features are general useful. If so, we may discuss on extracting some changes to own PR, adding configuration flags, testing, implementation review etc..