### PR TITLE
Add options parameter

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -280,6 +280,7 @@ export async function generate(
             namedImports: [
                 { name: "Client", alias: "SoapClient" },
                 { name: "createClientAsync", alias: "soapCreateClientAsync" },
+                { name: "IExOptions", alias: "ISoapExOptions" }
             ],
         });
         clientFile.addImportDeclarations(clientImports);
@@ -298,6 +299,11 @@ export async function generate(
                         {
                             name: camelcase(method.paramName),
                             type: method.paramDefinition ? method.paramDefinition.name : "{}",
+                        },
+                        {
+                            name: "options",
+                            type: "ISoapExOptions",
+                            hasQuestionToken: true,
                         },
                     ],
                     returnType: `Promise<[result: ${


### PR DESCRIPTION
resolves #42

This PR adds an optional `options` parameter to all methods.
This capability is supported by `node-soap`  and only needed to be exposed.

Not sure about testing - I ran tests before and after this change and the results are the same.