### PR TITLE
Reduce constraints on "soap" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint": "^8.13.0",
     "eslint-plugin-prettier": "^4.0.0",
     "sanitize-filename": "^1.6.3",
-    "soap": "1.0.0",
+    "soap": "^1.0.0",
     "supports-color": "^8.1.1",
     "ts-morph": "^14.0.0",
     "yargs": "^16.2.0"


### PR DESCRIPTION
This simply reduces the constraints on the version of the `soap` dependency to allow for more recent minor and patch versions (which do exist).

We are using [npm overrides](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides) to update this and its transitive dependencies, but unless there was a specific reason for making this exact, it should probably be updated here instead.