### PR TITLE
Add fileSuffix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0] - TBD
+
+- Generator: Appends `fileSuffix` to imports and exports
+- CLI: Add `--fileSuffix` option
+- Project: Updated README with latest CLI help output
+
 ## [1.5.0] - 2024-04-16
 
 - Project: Update soap dependency to 1.0.0 [#73](https://github.com/dderevjanik/wsdl-tsclient/pull/73) by @taylorreece

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Options:
       --emitDefinitionsOnly         Generate only Definitions          [boolean]
       --modelNamePreffix            Prefix for generated interface names[string]
       --modelNameSuffix             Suffix for generated interface names[string]
+      --fileSuffix                  The filename suffix used in import/export
+                                    statements (e.g. ".js" or ".mjs")   [string]
       --caseInsensitiveNames        Case-insensitive name while parsing
                                     definition names                   [boolean]
       --maxRecursiveDefinitionName  Maximum count of definition's with same name

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,10 @@ const conf = yargs(process.argv.slice(2))
         type: "string",
         description: "Suffix for generated interface names",
     })
+    .option("fileSuffix", {
+        type: "string",
+        description: 'The filename suffix used in import/export statements (e.g. ".js" or ".mjs")',
+    })
     .option("caseInsensitiveNames", {
         type: "boolean",
         description: "Case-insensitive name while parsing definition names",
@@ -96,6 +100,10 @@ if (conf.modelNamePreffix) {
 
 if (conf.modelNameSuffix) {
     options.modelNameSuffix = conf.modelNameSuffix;
+}
+
+if (conf.fileSuffix) {
+    options.fileSuffix = conf.fileSuffix;
 }
 
 if (conf.maxRecursiveDefinitionName || conf.maxRecursiveDefinitionName == 0) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -15,11 +15,13 @@ import { Logger } from "./utils/logger";
 export interface GeneratorOptions {
     emitDefinitionsOnly: boolean;
     modelPropertyNaming: ModelPropertyNaming;
+    fileSuffix: string;
 }
 
 const defaultOptions: GeneratorOptions = {
     emitDefinitionsOnly: false,
     modelPropertyNaming: null,
+    fileSuffix: "",
 };
 
 /**
@@ -105,7 +107,7 @@ function generateDefinitionFile(
             }
             // If a property is of the same type as its parent type, don't add import
             if (prop.ref.name !== definition.name) {
-                addSafeImport(definitionImports, `./${prop.ref.name}`, prop.ref.name);
+                addSafeImport(definitionImports, `./${prop.ref.name}${options.fileSuffix}`, prop.ref.name);
             }
             definitionProperties.push(createProperty(prop.name, prop.ref.name, prop.sourceName, prop.isArray));
         }
@@ -177,13 +179,13 @@ export async function generate(
                         );
                         addSafeImport(
                             clientImports,
-                            `./definitions/${method.paramDefinition.name}`,
+                            `./definitions/${method.paramDefinition.name}${mergedOptions.fileSuffix}`,
                             method.paramDefinition.name
                         );
                     }
                     addSafeImport(
                         portImports,
-                        `../definitions/${method.paramDefinition.name}`,
+                        `../definitions/${method.paramDefinition.name}${mergedOptions.fileSuffix}`,
                         method.paramDefinition.name
                     );
                 }
@@ -200,13 +202,13 @@ export async function generate(
                         );
                         addSafeImport(
                             clientImports,
-                            `./definitions/${method.returnDefinition.name}`,
+                            `./definitions/${method.returnDefinition.name}${mergedOptions.fileSuffix}`,
                             method.returnDefinition.name
                         );
                     }
                     addSafeImport(
                         portImports,
-                        `../definitions/${method.returnDefinition.name}`,
+                        `../definitions/${method.returnDefinition.name}${mergedOptions.fileSuffix}`,
                         method.returnDefinition.name
                     );
                 }
@@ -230,7 +232,7 @@ export async function generate(
                 });
             } // End of PortMethod
             if (!mergedOptions.emitDefinitionsOnly) {
-                addSafeImport(serviceImports, `../ports/${port.name}`, port.name);
+                addSafeImport(serviceImports, `../ports/${port.name}${mergedOptions.fileSuffix}`, port.name);
                 servicePorts.push({
                     name: sanitizePropName(port.name),
                     isReadonly: true,
@@ -252,7 +254,7 @@ export async function generate(
         } // End of Port
 
         if (!mergedOptions.emitDefinitionsOnly) {
-            addSafeImport(clientImports, `./services/${service.name}`, service.name);
+            addSafeImport(clientImports, `./services/${service.name}${mergedOptions.fileSuffix}`, service.name);
             clientServices.push({ name: sanitizePropName(service.name), type: service.name });
 
             serviceFile.addImportDeclarations(serviceImports);
@@ -280,7 +282,7 @@ export async function generate(
             namedImports: [
                 { name: "Client", alias: "SoapClient" },
                 { name: "createClientAsync", alias: "soapCreateClientAsync" },
-                { name: "IExOptions", alias: "ISoapExOptions" }
+                { name: "IExOptions", alias: "ISoapExOptions" },
             ],
         });
         clientFile.addImportDeclarations(clientImports);
@@ -339,7 +341,7 @@ export async function generate(
     indexFile.addExportDeclarations(
         allDefinitions.map((def) => ({
             namedExports: [def.name],
-            moduleSpecifier: `./definitions/${def.name}`,
+            moduleSpecifier: `./definitions/${def.name}${mergedOptions.fileSuffix}`,
         }))
     );
     if (!mergedOptions.emitDefinitionsOnly) {
@@ -348,19 +350,19 @@ export async function generate(
         indexFile.addExportDeclarations([
             {
                 namedExports: ["createClientAsync", `${parsedWsdl.name}Client`],
-                moduleSpecifier: "./client",
+                moduleSpecifier: `./client${mergedOptions.fileSuffix}`,
             },
         ]);
         indexFile.addExportDeclarations(
             parsedWsdl.services.map((service) => ({
                 namedExports: [service.name],
-                moduleSpecifier: `./services/${service.name}`,
+                moduleSpecifier: `./services/${service.name}${mergedOptions.fileSuffix}`,
             }))
         );
         indexFile.addExportDeclarations(
             parsedWsdl.ports.map((port) => ({
                 namedExports: [port.name],
-                moduleSpecifier: `./ports/${port.name}`,
+                moduleSpecifier: `./ports/${port.name}${mergedOptions.fileSuffix}`,
             }))
         );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,11 @@ export interface Options {
      */
     modelNameSuffix: string;
     /**
+     * The filename suffix used in import/export statements (e.g. ".js" or ".mjs")
+     * @default ""
+     */
+    fileSuffix: string;
+    /**
      * Case-insensitive name while parsing definition names
      * @default false
      */
@@ -66,6 +71,7 @@ export const defaultOptions: Options = {
     verbose: false,
     quiet: false,
     colors: true,
+    fileSuffix: "",
 };
 
 export async function parseAndGenerate(

--- a/test/resources-public/productssuffix.test.ts
+++ b/test/resources-public/productssuffix.test.ts
@@ -1,0 +1,29 @@
+import test from "tape";
+import { existsSync } from "fs";
+import { parseAndGenerate } from "../../src";
+import { Logger } from "../../src/utils/logger";
+import { typecheck } from "../utils/tsc";
+
+const target = "productssuffix";
+
+test(target, async (t) => {
+    Logger.disabled();
+
+    const input = `./test/resources-public/${target}.wsdl`;
+    const outdir = "./test/generated";
+
+    t.test(`${target} - generate wsdl client`, async (t) => {
+        await parseAndGenerate(input, outdir, { fileSuffix: ".js" });
+        t.end();
+    });
+
+    t.test(`${target} - check definitions`, async (t) => {
+        t.equal(existsSync(`${outdir}/${target}/definitions/KeyValuePair.ts`), true);
+        t.end();
+    });
+
+    t.test(`${target} - compile`, async (t) => {
+        await typecheck(`${outdir}/${target}/index.ts`);
+        t.end();
+    });
+});

--- a/test/resources-public/productssuffix.wsdl
+++ b/test/resources-public/productssuffix.wsdl
@@ -1,0 +1,1 @@
+products.wsdl


### PR DESCRIPTION
TypeScript projects that use several `moduleResolution` settings (including "NodeNext") require that file imports include the entire filename (with extension) in their references.

This adds a `--fileSuffix` option which can be set to `.js` in these scenarios.