### PR TITLE
ESlint fixes plus other minor improvements

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -280,7 +280,7 @@ export async function generate(
             namedImports: [
                 { name: "Client", alias: "SoapClient" },
                 { name: "createClientAsync", alias: "soapCreateClientAsync" },
-                { name: "IExOptions", alias: "ISoapExOptions" }
+                { name: "IExOptions", alias: "ISoapExOptions" },
             ],
         });
         clientFile.addImportDeclarations(clientImports);


### PR DESCRIPTION
This PR contains some ESlint fixes, plus some minor improvements (most were SonarQube suggestions):

- Remove the `e.stack.split("\n").slice(0, 2).join("\n") + "\n" + err.stack;` expressions, because they had no effect
- Renamed `toPrimitedType` to `toPrimitiveType` (typo)
- Refactored nested `if ... else { if .... }` to `if ... else if .... else if`
- Replace `type ? type : parseDefinition(...)` with more concise `type ?? parseDefinition(...)`
- Removed unread variable `allMethods`

*edit*: the eslint things are also handled in #81, I might rebase after that one gets merged