### PR TITLE
Fixed: Output message without nested element defaulted to request type

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -287,11 +287,11 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                             Logger.debug(`Parsing Method ${methodName}`);
 
                             // TODO: Deduplicate code below by refactoring it to external function. Is it even possible ?
-                            let paramName = "request";
+                            let requestParamName = "request";
                             let inputDefinition: Definition = null; // default type
                             if (method.input) {
                                 if (method.input.$name) {
-                                    paramName = method.input.$name;
+                                    requestParamName = method.input.$name;
                                 }
                                 const inputMessage = wsdl.definitions.messages[method.input.$name];
                                 if (inputMessage.element) {
@@ -311,15 +311,15 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                                             visitedDefinitions
                                         );
                                 } else if (inputMessage.parts) {
-                                    const type = parsedWsdl.findDefinition(paramName);
+                                    const type = parsedWsdl.findDefinition(requestParamName);
                                     inputDefinition =
                                         type ??
                                         parseDefinition(
                                             parsedWsdl,
                                             mergedOptions,
-                                            paramName,
+                                            requestParamName,
                                             inputMessage.parts,
-                                            [paramName],
+                                            [requestParamName],
                                             visitedDefinitions
                                         );
                                 } else {
@@ -329,8 +329,12 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                                 }
                             }
 
+                            let responseParamName = "response";
                             let outputDefinition: Definition = null; // default type, `{}` or `unknown` ?
                             if (method.output) {
+                                if (method.output.$name) {
+                                    responseParamName = method.output.$name;
+                                }
                                 const outputMessage = wsdl.definitions.messages[method.output.$name];
                                 if (outputMessage.element) {
                                     // TODO: if `$type` not defined, inline type into function declartion (do not create definition file) - wsimport
@@ -347,21 +351,21 @@ export async function parseWsdl(wsdlPath: string, options: Partial<ParserOptions
                                             visitedDefinitions
                                         );
                                 } else {
-                                    const type = parsedWsdl.findDefinition(paramName);
+                                    const type = parsedWsdl.findDefinition(responseParamName);
                                     outputDefinition =
                                         type ??
                                         parseDefinition(
                                             parsedWsdl,
                                             mergedOptions,
-                                            paramName,
+                                            responseParamName,
                                             outputMessage.parts,
-                                            [paramName],
+                                            [responseParamName],
                                             visitedDefinitions
                                         );
                                 }
                             }
 
-                            const camelParamName = changeCase(paramName);
+                            const camelParamName = changeCase(requestParamName);
                             const portMethod: Method = {
                                 name: methodName,
                                 paramName: reservedKeywords.includes(camelParamName)

--- a/test/node-soap/hello_service.test.ts
+++ b/test/node-soap/hello_service.test.ts
@@ -4,7 +4,7 @@ import { parseAndGenerate } from "../../src";
 import { Logger } from "../../src/utils/logger";
 import { typecheck } from "../utils/tsc";
 
-const target = "ref_element_same_as_type";
+const target = "hello_service";
 
 test(target, async (t) => {
     Logger.disabled();
@@ -12,20 +12,29 @@ test(target, async (t) => {
     const input = `./test/resources/${target}.wsdl`;
     const outdir = "./test/generated";
 
+    const expectedFiles = [
+        "client.ts",
+        "index.ts",
+        "definitions/SayHelloRequest.ts",
+        "definitions/SayHelloResponse.ts",
+        "ports/HelloPort.ts",
+        "services/HelloService.ts",
+    ];
+
     t.test(`${target} - generate wsdl client`, async (t) => {
         await parseAndGenerate(input, outdir);
         t.end();
     });
 
-    t.test(`${target} - check definitions`, async (t) => {
-        t.equal(existsSync(`${outdir}/refelementsameastype/definitions/ExampleContent.ts`), true);
-        t.equal(existsSync(`${outdir}/refelementsameastype/definitions/OutMessage.ts`), true);
-        t.equal(existsSync(`${outdir}/refelementsameastype/definitions/V1ExampleRequestType.ts`), true);
-        t.end();
+    expectedFiles.forEach((file) => {
+        t.test(`${target} - ${file} exists`, async (t) => {
+            t.equal(existsSync(`${outdir}/helloservice/${file}`), true);
+            t.end();
+        });
     });
 
     t.test(`${target} - compile`, async (t) => {
-        await typecheck(`${outdir}/refelementsameastype/index.ts`);
+        await typecheck(`${outdir}/helloservice/index.ts`);
         t.end();
     });
 });

--- a/test/resources/hello_service.wsdl
+++ b/test/resources/hello_service.wsdl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="HelloService"
+    targetNamespace="http://www.examples.com/wsdl/HelloService.wsdl"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tns="http://www.examples.com/wsdl/HelloService.wsdl"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <message name="SayHelloRequest">
+        <part name="firstName" type="xsd:string" />
+    </message>
+    <message name="SayHelloResponse">
+        <part name="greeting" type="xsd:string" />
+    </message>
+    <portType name="Hello_PortType">
+        <operation name="sayHello">
+            <input message="tns:SayHelloRequest" />
+            <output message="tns:SayHelloResponse" />
+        </operation>
+    </portType>
+    <binding name="Hello_Binding" type="tns:Hello_PortType">
+        <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http" />
+        <operation name="sayHello">
+            <soap:operation soapAction="sayHello" />
+            <input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                    namespace="urn:examples:helloservice" use="encoded" />
+            </input>
+            <output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                    namespace="urn:examples:helloservice" use="encoded" />
+            </output>
+        </operation>
+    </binding>
+    <service name="Hello_Service">
+        <documentation>WSDL File for HelloService</documentation>
+        <port binding="tns:Hello_Binding" name="Hello_Port">
+            <soap:address location="http://localhost:51515/SayHello/" />
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
This fixes #76.

I've added the hello service WSDL from the above issue, which has a port definition:
```xml
    <portType name="Hello_PortType">
        <operation name="sayHello">
            <input message="tns:SayHelloRequest" />
            <output message="tns:SayHelloResponse" />
        </operation>
    </portType>
```

The issue author was noticing that the `SayHelloResponse` file is never generated.

The cause was that the port definition was wrongly parsed, because the default param name 'request' was also used for responses, but only when the response _has no nested element_ (like the `SayHelloResponse` above).

To fix it, I've used a separate `requestParamName` and `responseParamName`. I'll refactor this in a future PR, because input and output message definition parsing is quite similar.

btw: As a result, the `ref_element_same_as_type.wsdl` tests also failed, because now the `OutputMessage` file is correctly outputted. It defaulted to the request type instead due to the parsing bug.