### PR TITLE
Make tsc invocation (during tests) work on windows as well

### DIFF
--- a/test/utils/tsc.ts
+++ b/test/utils/tsc.ts
@@ -1,8 +1,10 @@
 import util from "util";
 
-const exec = util.promisify(require('child_process').exec);
-const pathToTsc = `./node_modules/.bin/tsc`;
+const exec = util.promisify(require("child_process").exec);
 
 export async function typecheck(pathToIndex: string) {
-    await exec(`${pathToTsc} ${pathToIndex} --noEmit`);
+    const cmd = `tsc ${pathToIndex} --noEmit`;
+    await exec(cmd, {
+        env: process.env,
+    });
 }

--- a/test/utils/tsc.ts
+++ b/test/utils/tsc.ts
@@ -3,8 +3,7 @@ import util from "util";
 const exec = util.promisify(require("child_process").exec);
 
 export async function typecheck(pathToIndex: string) {
-    const cmd = `tsc ${pathToIndex} --noEmit`;
-    await exec(cmd, {
+    await exec(`tsc ${pathToIndex} --noEmit`, {
         env: process.env,
     });
 }


### PR DESCRIPTION
On Windows 11, running git bash and node v20.12.2, running `npm test` results in:

![image](https://github.com/dderevjanik/wsdl-tsclient/assets/635784/156573c8-7d6f-4ac6-8893-e21e06407d86)

This PR fixes that by not assuming `./node_modules/.bin/tsc`, but rather by invoking the `tsc` command plainly with the process environment variables, and letting `exec()` figure it out.