### PR TITLE
fix: wire --esm cli flag to options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,6 +123,10 @@ if (conf.caseInsensitiveNames) {
     options.caseInsensitiveNames = conf.caseInsensitiveNames;
 }
 
+if (conf.esm) {
+    options.esm = conf.esm;
+}
+
 Logger.debug("Options");
 Logger.debug(JSON.stringify(options, null, 2));
 


### PR DESCRIPTION
Likely forgotten in bde049045da8493945f62d373b11c8ca8643e6c6. Fixes #91.